### PR TITLE
Change submit tagName to button

### DIFF
--- a/app/templates/components/ember-form-master-2000/fm-submit.hbs
+++ b/app/templates/components/ember-form-master-2000/fm-submit.hbs
@@ -3,6 +3,8 @@
   {{bind-attr disabled=disabled}}
   {{bind-attr class=submitButtonClasses}}
   type="submit">
+  {{#if value}}
     {{value}}
-    {{yield}}
+  {{/if}}
+  {{yield}}
 </button>

--- a/app/templates/components/ember-form-master-2000/fm-submit.hbs
+++ b/app/templates/components/ember-form-master-2000/fm-submit.hbs
@@ -1,5 +1,8 @@
-<input
+<button
   {{bind-attr value=value}}
   {{bind-attr disabled=disabled}}
   {{bind-attr class=submitButtonClasses}}
   type="submit">
+    {{value}}
+    {{yield}}
+</button>

--- a/tests/unit/components/fm-submit-test.js
+++ b/tests/unit/components/fm-submit-test.js
@@ -18,7 +18,7 @@ moduleForComponent('fm-submit', {
 test('fm-submit renders properly', function(assert) {
   var component = this.subject();
   this.render();
-  assert.equal(component.$('input:submit').length, 1, 'Renders submit element');
+  assert.equal(component.$('button:submit').length, 1, 'Renders submit element');
   assert.ok(component.$().hasClass('form-group'), 'Has the class of form-control');
 });
 
@@ -26,17 +26,17 @@ test('fm-submit allows custom class names on the input element', function(assert
   this.container.lookup('fmconfig:main').submitButtonClasses = ['button', 'another-class'];
   var component = this.subject();
   this.render();
-  assert.ok(component.$('input').hasClass('button'), 'It has the .button class');
-  assert.ok(component.$('input').hasClass('button'), 'It has the .another-class class');
+  assert.ok(component.$('button').hasClass('button'), 'It has the .button class');
+  assert.ok(component.$('button').hasClass('button'), 'It has the .another-class class');
 });
 
 test('fm-submit can be disabled', function(assert) {
   var component = this.subject();
   component.set('disabled', true);
   this.render();
-  assert.ok(component.$('input:disabled').length, 'It rendered a disabled submit');
+  assert.ok(component.$('button:disabled').length, 'It rendered a disabled submit');
   Ember.run(function() {
     component.set('disabled', false);
   });
-  assert.ok(!component.$('input:disabled').length, 'It rendered a submit that is not disabled');
+  assert.ok(!component.$('button:disabled').length, 'It rendered a submit that is not disabled');
 });


### PR DESCRIPTION
The current implementation of ``<input type="submit"/>`` is bad because it reduces accessibility in some screen readers.  Furthermore, the ``button`` attribute should be used in favour of HTML5.  Finally, the ``input`` element is misleading in that it is not a "modifiable" control; it merely serves one purpose, and that is to trigger the ``submit`` action.

This change allows the user to pass in extra content into a button (such as an icon):

```
{{#fm-submit value="Let's go"}}{{custom-icon icon="user" title="My nested icon content"}}{{/fm-submit}}
```