### PR TITLE
Fix unchecked radio initial state

### DIFF
--- a/addon/components/fm-radio.js
+++ b/addon/components/fm-radio.js
@@ -7,9 +7,9 @@ export default Ember.Component.extend({
     return this.fmconfig.radioClass;
   }),
   checked: false,
-  updateChecked: Ember.observer('parentView.value', function() {
+  updateChecked: Ember.on('init', Ember.observer('parentView.value', function() {
     this.set('checked', this.get('parentView.value') === this.get('value'));
-  }),
+  })),
   labelText: Ember.computed('parentView.optionLabelPath', 'content', function() {
     if(this.get('parentView.optionLabelPath')) {
       return this.get(this.get('parentView.optionLabelPath'));

--- a/tests/unit/components/fm-radio-group-test.js
+++ b/tests/unit/components/fm-radio-group-test.js
@@ -31,3 +31,16 @@ test('renders radio buttons for each content item provided', function(assert) {
   this.render();
   assert.equal(component.$('.radio').length, 2, 'fm-radio-group rendered two radio buttons');
 });
+
+test('preselects the proper radio', function(assert) {
+  var component = this.subject();
+  component.set('optionLabelPath', 'content.label');
+  component.set('optionValuePath', 'content.value');
+  component.set('value', 'two');
+  component.set('content', Ember.A([{label: 'label', value: 'value'}, {label: 'two', value: 'two'}]));
+  this.render();
+
+  var checkedRadio = component.$(':checked');
+  assert.equal(checkedRadio.length, 1, 'fm-radio-group has an initial checked value');
+  assert.equal(checkedRadio.attr('value'), 'two', 'fm-radio-group initial checked value is correct');
+});


### PR DESCRIPTION
Forces radio’s `updateChecked` to run on init, thus taking the initial value into account when doing the initial render.

You can reproduce the issue quite easily by setting a value in the dummy app — the initial rendered state does not have this value set.