### PR TITLE
Change labelClass from function to property

### DIFF
--- a/addon/components/fm-radio-group.js
+++ b/addon/components/fm-radio-group.js
@@ -11,7 +11,7 @@ export default Ember.Component.extend({
   radioGroupWrapperClass: Ember.computed(function() {
     return this.fmconfig.radioGroupWrapperClass;
   }),
-  labelClass: function() {
+  labelClass: Ember.computed(function() {
     return this.fmconfig.labelClass;
-  }
+  })
 });


### PR DESCRIPTION
Getting `labelClass` from the template would output the stringified version
of the function, because it wasn't a computed property. This fixes it.