### PR TITLE
[BUGFIX]: Data-* attributes not allowed through

### DIFF
--- a/addon/components/fm-field.js
+++ b/addon/components/fm-field.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
     if(!this.get('optionLabelPath')) {
       this.set('optionLabelPath', 'content.label');
     }
-    var dataAttributes = Ember.keys(this).filter(function(attr) {
+    var dataAttributes = Object.keys(this.get('attrs') || {}).filter(function(attr) {
       return /data-/.test(attr);
     });
     this.set('dataAttributes', dataAttributes);


### PR DESCRIPTION
While there appears to be test coverage to check that data-* attributes are allowed through, this is not currently working with the latest versions of Ember  (1.13.4) and this plugin (0.2.0).

I'm using `data-test` attributes extensively in my acceptance tests and after tracking down the failures, noticed the dummy app appears to suffer from the same issue.

<img width="758" alt="screen shot 2015-07-19 at 11 32 34" src="https://cloud.githubusercontent.com/assets/366944/8765395/1404960a-2e0a-11e5-9445-790f1e6af4f7.png">

The data-test attribute is defined in the template [here](https://github.com/Emerson/ember-form-master-2000/blob/master/tests/dummy/app/templates/index.hbs#L22).

I've tracked this down, as seen in the commit, to how we currently attempt to find data-* attributes. They are not available on the object itself, but on the object's `attrs` property.  I'm not sure if/when this changed on Ember's side, or if this is compatible with other versions of Ember, but all tests pass are passing.  The only concern is that the current tests didn't catch this regression, but I'm not sure how to improve that within a component unit test.

This shows the markup after this change:

<img width="900" alt="screen shot 2015-07-19 at 12 19 14" src="https://cloud.githubusercontent.com/assets/366944/8765540/6987ce98-2e10-11e5-82d4-faa1f3090199.png">