### PR TITLE
fix removed in Ember 2.0 Handlebars.makeBoundHelper

### DIFF
--- a/addon/helpers/is-equal.js
+++ b/addon/helpers/is-equal.js
@@ -1,7 +1,11 @@
 import Ember from 'ember';
 
-function isEqualHelper(first, second) {
+function oldIsEqualHelper(first, second) {
   return first === second;
+}
+
+function isEqualHelper(params) {
+  return params[0] === params[1];
 }
 
 var forExport = null;
@@ -11,7 +15,7 @@ if (Ember.Helper) {
 } else if (Ember.HTMLBars.makeBoundHelper) {
   forExport = Ember.HTMLBars.makeBoundHelper(isEqualHelper);
 } else if (Ember.Handlebars.makeBoundHelper) {
-  Ember.Handlebars.makeBoundHelper(isEqualHelper)
+  Ember.Handlebars.makeBoundHelper(oldIsEqualHelper)
 }
 
 export default forExport;

--- a/addon/helpers/is-equal.js
+++ b/addon/helpers/is-equal.js
@@ -4,4 +4,14 @@ function isEqualHelper(first, second) {
   return first === second;
 }
 
-export default Ember.Handlebars.makeBoundHelper(isEqualHelper);
+var forExport = null;
+
+if (Ember.Helper) {
+  forExport = Ember.Helper.helper(isEqualHelper);
+} else if (Ember.HTMLBars.makeBoundHelper) {
+  forExport = Ember.HTMLBars.makeBoundHelper(isEqualHelper);
+} else if (Ember.Handlebars.makeBoundHelper) {
+  Ember.Handlebars.makeBoundHelper(isEqualHelper)
+}
+
+export default forExport;

--- a/addon/helpers/is-not.js
+++ b/addon/helpers/is-not.js
@@ -4,4 +4,14 @@ function isNotHelper(first) {
   return !first;
 }
 
-export default Ember.Handlebars.makeBoundHelper(isNotHelper);
+var forExport = null;
+
+if (Ember.Helper) {
+  forExport = Ember.Helper.helper(isNotHelper);
+} else if (Ember.HTMLBars.makeBoundHelper) {
+  forExport = Ember.HTMLBars.makeBoundHelper(isNotHelper);
+} else if (Ember.Handlebars.makeBoundHelper) {
+  Ember.Handlebars.makeBoundHelper(isNotHelper)
+}
+
+export default forExport;

--- a/addon/helpers/is-not.js
+++ b/addon/helpers/is-not.js
@@ -1,7 +1,11 @@
 import Ember from 'ember';
 
-function isNotHelper(first) {
+function oldIsNotHelper(first) {
   return !first;
+}
+
+function isNotHelper(params) {
+  return !params[0];
 }
 
 var forExport = null;
@@ -11,7 +15,7 @@ if (Ember.Helper) {
 } else if (Ember.HTMLBars.makeBoundHelper) {
   forExport = Ember.HTMLBars.makeBoundHelper(isNotHelper);
 } else if (Ember.Handlebars.makeBoundHelper) {
-  Ember.Handlebars.makeBoundHelper(isNotHelper)
+  Ember.Handlebars.makeBoundHelper(oldIsNotHelper)
 }
 
 export default forExport;

--- a/addon/helpers/read-path.js
+++ b/addon/helpers/read-path.js
@@ -1,7 +1,11 @@
 import Ember from 'ember';
 
-function readPathHelper(object, path) {
+function oldReadPathHelper(object, path) {
   return Ember.get(object, path);
+}
+
+function readPathHelper(params) {
+  return Ember.get(params[0], params[1]);
 }
 
 var forExport = null;
@@ -11,7 +15,7 @@ if (Ember.Helper) {
 } else if (Ember.HTMLBars.makeBoundHelper) {
   forExport = Ember.HTMLBars.makeBoundHelper(readPathHelper);
 } else if (Ember.Handlebars.makeBoundHelper) {
-  Ember.Handlebars.makeBoundHelper(readPathHelper)
+  Ember.Handlebars.makeBoundHelper(oldReadPathHelper)
 }
 
 export default forExport;

--- a/addon/helpers/read-path.js
+++ b/addon/helpers/read-path.js
@@ -4,4 +4,14 @@ function readPathHelper(object, path) {
   return Ember.get(object, path);
 }
 
-export default Ember.Handlebars.makeBoundHelper(readPathHelper);
+var forExport = null;
+
+if (Ember.Helper) {
+  forExport = Ember.Helper.helper(readPathHelper);
+} else if (Ember.HTMLBars.makeBoundHelper) {
+  forExport = Ember.HTMLBars.makeBoundHelper(readPathHelper);
+} else if (Ember.Handlebars.makeBoundHelper) {
+  Ember.Handlebars.makeBoundHelper(readPathHelper)
+}
+
+export default forExport;


### PR DESCRIPTION
All Handlebars APIs are removed in Ember 2.0. This includes:

Ember.Handlebars.helper, Ember.Handlebars.makeBoundHelper and Ember.Handlebars.helper