### PR TITLE
Fix typo and add maxlength to basic input field

### DIFF
--- a/addon/templates/components/ember-form-master-2000/fm-field.hbs
+++ b/addon/templates/components/ember-form-master-2000/fm-field.hbs
@@ -7,6 +7,7 @@
     type=type
     value=value
     classNameBindings='errorClass inputClass'
+    maxlength=maxlength
     placeholder=placeholder}}
 {{/if}}
 
@@ -27,7 +28,7 @@
     placeholder=placeholder
     rows=rows
     cols=cols
-    maxlengh=maxlengh
+    maxlength=maxlength
     spellcheck=spellcheck
     disabled=disabled
   }}


### PR DESCRIPTION
Fix the typo in maxlength, and add it to the normal input too, because it is supported in [the spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes).