### PR TITLE
Fix: do not apply has-error class if errors array is empty

### DIFF
--- a/addon/components/fm-checkbox.js
+++ b/addon/components/fm-checkbox.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
     return this.get('fmConfig.checkboxWrapperClass');
   }),
   errorClass: Ember.computed('errors', function() {
-    if(this.get('errors')) {
+    if(!Ember.isEmpty(this.get('errors'))) {
       return this.get('fmConfig.errorClass');
     }
   })

--- a/addon/components/fm-field.js
+++ b/addon/components/fm-field.js
@@ -35,7 +35,7 @@ export default Ember.Component.extend({
   label: null,
   classNameBindings: ['wrapperClass', 'errorClass'],
   errorClass: Ember.computed('errors', function() {
-    if(this.get('errors')) {
+    if(!Ember.isEmpty(this.get('errors'))) {
       return this.get('fmConfig.errorClass');
     }
   }),

--- a/addon/components/fm-radio-group.js
+++ b/addon/components/fm-radio-group.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
   classNameBindings: ['radioGroupWrapperClass', 'errorClass'],
   fmConfig: Ember.inject.service('fm-config'),
   errorClass: Ember.computed('errors', function() {
-    if(this.get('errors')) {
+    if(!Ember.isEmpty(this.get('errors'))) {
       return this.get('fmConfig.errorClass');
     }
   }),


### PR DESCRIPTION
Boolean([]) === true therefore an empty errors array caused `has-error` class.

Run in this issue when using `ember-cp-validations` which provides an empty `validations.attrs.<attribute-name>.messages` array if model is valid.