### PR TITLE
Fix issues with fm-select in Ember 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ You can see the basic dummy app here:
     optionValuePath='id'
     optionLabelPath='label'
     prompt='Select Something'
+    value=model.valueToSelect
+    action=(action (mut model.valueToSelect))
   }}
 
   {{fm-field

--- a/addon/components/fm-field.js
+++ b/addon/components/fm-field.js
@@ -63,5 +63,15 @@ export default Ember.Component.extend({
     id = id.replace(/[\.,\/#!$%\^&\*;:{}=\`'"~()]/g,"");
     id = id.replace(/\s/g, "-");
     return id;
+  },
+
+  actions: {
+    selectAction(value){
+      if (this.attrs.action && typeof this.attrs.action === 'function'){
+        this.attrs.action(value);
+      } else {
+        this.set('value', value);
+      }
+    }
   }
 });

--- a/addon/components/fm-select.js
+++ b/addon/components/fm-select.js
@@ -44,8 +44,7 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    change: function() {
-
+    change(){
       const selectEl = this.$()[0];
       const selectedIndex = selectEl.selectedIndex;
       const content = this.get('content');
@@ -54,7 +53,7 @@ export default Ember.Component.extend({
       const hasPrompt = !!this.get('prompt');
       const contentIndex = hasPrompt ? selectedIndex - 1 : selectedIndex;
 
-      const selection = content[contentIndex];
+      const selection = content.objectAt(contentIndex);
 
       // set the local, shadowed selection to avoid leaking
       // changes to `selection` out via 2-way binding

--- a/addon/components/fm-select.js
+++ b/addon/components/fm-select.js
@@ -59,14 +59,9 @@ export default Ember.Component.extend({
       // changes to `selection` out via 2-way binding
       this.set('_selection', selection);
 
-      // propagate the select up to the parent view
-      if(this.get('parentView') && selection) {
-        const selectedValue = Ember.get(selection, this.get('optionValuePath'));
-        this.set('parentView.value', selectedValue);
-      }
-
-      const changeCallback = this.get('action');
-      changeCallback(selection);
+      const path = this.get('optionValuePath');
+      const value = (path.length > 0)? Ember.get(selection, path) : selection;
+      this.attrs.action(value);
     }
   }
 

--- a/addon/helpers/is-equal.js
+++ b/addon/helpers/is-equal.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 function isEqualHelper(params) {
-  return params[0] === params[2];
+  return params[0] === params[1];
 }
 
 var forExport = null;

--- a/addon/templates/components/ember-form-master-2000/fm-field.hbs
+++ b/addon/templates/components/ember-form-master-2000/fm-field.hbs
@@ -18,6 +18,7 @@
     optionLabelPath=optionLabelPath
     prompt=prompt
     value=value
+    action=(action 'selectAction')
   }}
 {{/if}}
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -30,6 +30,7 @@
         optionLabelPath='label'
         prompt='Select Something'
         value=model.exampleModel.language
+        action=(action (mut model.exampleModel.language))
         errors=model.exampleModel.errors.language
       }}
 

--- a/tests/integration/components/fm-field-test.js
+++ b/tests/integration/components/fm-field-test.js
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 // import {initialize} from 'ember-form-master-2000/initializers/fm-initialize';
 
@@ -32,10 +33,20 @@ test('renders properly', function(assert) {
 //   assert.ok(this.$('label').length === 0, 'A label was rendered when it should not have been');
 // });
 //
-// test('type="select" renders a select', function(assert) {
-//   this.render(hbs `{{fm-field type="select"}}`);
-//   assert.ok(this.$('select').length === 1, 'A select was not rendered when it should have been');
-// });
+
+test('type="select" renders a select', function(assert) {
+  this.render(hbs `{{fm-field type="select"}}`);
+  assert.ok(this.$('select').length === 1, 'A select was not rendered when it should have been');
+});
+
+test('action is passed down to select component', function(assert) {
+  //assert.expect(1);
+  this.set('assertCalled', () => assert.ok(true));
+  this.set('content', Ember.A(['something',]));
+  this.render(hbs `{{fm-field type="select" content=content action=(action assertCalled)}}`);
+  this.$('select').change();
+});
+
 //
 // test('type="textarea" renders a textarea', function(assert) {
 //   this.render(hbs `{{fm-field type="textarea"}}`);

--- a/tests/integration/components/fm-select-test.js
+++ b/tests/integration/components/fm-select-test.js
@@ -1,7 +1,7 @@
  import Ember from 'ember';
  import { moduleForComponent, test } from 'ember-qunit';
  import hbs from 'htmlbars-inline-precompile';
- import {initialize} from 'ember-form-master-2000/initializers/fm-initialize';
+ import {initialize} from 'ember-form-master-2000/initializers/ember-form-master-2000';
 
  moduleForComponent('fm-select', 'Integration | Component | fm-select', {
    integration: true,
@@ -44,18 +44,27 @@
    assert.equal(this.$('option:last').attr('value'), 'goodbye');
  });
 
- test('fm-select updates the value of the parentView', function(assert) {
-   this.set('parentView', Ember.View.create({
-     value: null
-   }));
+ test('fm-select calls `action` with newly chosen value', function(assert) {
    this.set('content', Ember.A([
      {label: 'one', value: 1},
      {label: 'two', value: 2}
    ]));
-   this.render(hbs `{{fm-select content=content parentView=parentView}}`);
+   this.render(hbs `{{fm-select content=content value=value action=(action (mut value))}}`);
    this.$('select').change();
-   assert.equal(this.$('option:selected').val(), this.get('parentView.value'));
+   assert.equal(this.$('option:selected').val(), this.get('value'));
  });
+
+test('fm-select updates the value of the fm-field by default', function(assert) {
+  this.set('value', null);
+  this.set('content', Ember.A([
+    {label: 'one', value: 1},
+    {label: 'two', value: 2}
+  ]));
+  this.render(hbs `{{fm-field type='select' optionValuePath='value'
+              optionValuePath='label' content=content value=value}}`);
+  this.$('select').change();
+  assert.equal(this.$('option:selected').val(), this.get('value'));
+});
 
  test('fm-select changes the selected option when the passed in value changes', function(assert) {
    this.set('modelValue', 2);

--- a/tests/integration/components/fm-select-test.js
+++ b/tests/integration/components/fm-select-test.js
@@ -1,77 +1,77 @@
-// import Ember from 'ember';
-// import { moduleForComponent, test } from 'ember-qunit';
-// import hbs from 'htmlbars-inline-precompile';
-// import {initialize} from 'ember-form-master-2000/initializers/fm-initialize';
-//
-// moduleForComponent('fm-select', 'Integration | Component | fm-select', {
-//   integration: true,
-//   setup: function() {
-//     this.container.inject = this.container.injection;
-//     initialize(null, this.container);
-//   }
-// });
-//
-// test('fm-select renders properly', function(assert) {
-//   this.render(hbs `{{fm-select}}`);
-//   assert.ok(this.$('select').length, 'Renders a select');
-//   assert.ok(this.$('.form-control').length === 1, 'Has the class of form-control');
-// });
-//
-// test('fm-select renders an array of content options', function(assert) {
-//   this.set('content', Ember.A([
-//     {label: 'one', value: 1},
-//     {label: 'two', value: 2}
-//   ]));
-//   this.render(hbs `{{fm-select content=content}}`);
-//   assert.ok(this.$('option').length === 2, 'It renders two options');
-//   assert.equal(this.$('option:first').text().trim(), 'one');
-//   assert.equal(this.$('option:last').text().trim(), 'two');
-//   assert.equal(this.$('option:first').attr('value'), 1);
-//   assert.equal(this.$('option:last').attr('value'), 2);
-// });
-//
-// test('fm-select respects different optionValuePaths and optionLabelPaths', function(assert) {
-//   this.set('content', Ember.A([
-//     {text: 'hi', itemValue: 'hello'},
-//     {text: 'bye', itemValue: 'goodbye'}
-//   ]));
-//   this.set('optionLabelPath', 'text');
-//   this.set('optionValuePath', 'itemValue');
-//   this.render(hbs `{{fm-select content=content optionLabelPath=optionLabelPath optionValuePath=optionValuePath}}`);
-//   assert.equal(this.$('option:first').text().trim(), 'hi');
-//   assert.equal(this.$('option:last').text().trim(), 'bye');
-//   assert.equal(this.$('option:first').attr('value'), 'hello');
-//   assert.equal(this.$('option:last').attr('value'), 'goodbye');
-// });
-//
-// test('fm-select updates the value of the parentView', function(assert) {
-//   this.set('parentView', Ember.View.create({
-//     value: null
-//   }));
-//   this.set('content', Ember.A([
-//     {label: 'one', value: 1},
-//     {label: 'two', value: 2}
-//   ]));
-//   this.render(hbs `{{fm-select content=content parentView=parentView}}`);
-//   this.$('select').change();
-//   assert.equal(this.$('option:selected').val(), this.get('parentView.value'));
-// });
-//
-// test('fm-select changes the selected option when the passed in value changes', function(assert) {
-//   this.set('modelValue', 2);
-//   this.set('content', Ember.A([
-//     {label: 'one', value: 1},
-//     {label: 'two', value: 2}
-//   ]));
-//   this.render(hbs `{{fm-select value=modelValue content=content}}`);
-//   assert.equal(this.$('option:selected').val(), '2', 'The initial value is set correctly');
-//   Ember.run(()=> {
-//     this.set('modelValue', 1);
-//     assert.equal(this.$('option:selected').val(), '1', 'The selected option updated properly');
-//   });
-// });
-//
-// test('it allows a prompt to be passed in', function(assert) {
-//   this.render(hbs `{{fm-select prompt="Testing"}}`);
-//   assert.ok(this.$('option:disabled').length === 1, 'A prompt option was not rendered as expected');
-// });
+ import Ember from 'ember';
+ import { moduleForComponent, test } from 'ember-qunit';
+ import hbs from 'htmlbars-inline-precompile';
+ import {initialize} from 'ember-form-master-2000/initializers/fm-initialize';
+
+ moduleForComponent('fm-select', 'Integration | Component | fm-select', {
+   integration: true,
+   setup: function() {
+     this.container.inject = this.container.injection;
+     initialize(null, this.container);
+   }
+ });
+
+ test('fm-select renders properly', function(assert) {
+   this.render(hbs `{{fm-select}}`);
+   assert.ok(this.$('select').length, 'Renders a select');
+   assert.ok(this.$('.form-control').length === 1, 'Has the class of form-control');
+ });
+
+ test('fm-select renders an array of content options', function(assert) {
+   this.set('content', Ember.A([
+     {label: 'one', value: 1},
+     {label: 'two', value: 2}
+   ]));
+   this.render(hbs `{{fm-select content=content}}`);
+   assert.ok(this.$('option').length === 2, 'It renders two options');
+   assert.equal(this.$('option:first').text().trim(), 'one');
+   assert.equal(this.$('option:last').text().trim(), 'two');
+   assert.equal(this.$('option:first').attr('value'), 1);
+   assert.equal(this.$('option:last').attr('value'), 2);
+ });
+
+ test('fm-select respects different optionValuePaths and optionLabelPaths', function(assert) {
+   this.set('content', Ember.A([
+     {text: 'hi', itemValue: 'hello'},
+     {text: 'bye', itemValue: 'goodbye'}
+   ]));
+   this.set('optionLabelPath', 'text');
+   this.set('optionValuePath', 'itemValue');
+   this.render(hbs `{{fm-select content=content optionLabelPath=optionLabelPath optionValuePath=optionValuePath}}`);
+   assert.equal(this.$('option:first').text().trim(), 'hi');
+   assert.equal(this.$('option:last').text().trim(), 'bye');
+   assert.equal(this.$('option:first').attr('value'), 'hello');
+   assert.equal(this.$('option:last').attr('value'), 'goodbye');
+ });
+
+ test('fm-select updates the value of the parentView', function(assert) {
+   this.set('parentView', Ember.View.create({
+     value: null
+   }));
+   this.set('content', Ember.A([
+     {label: 'one', value: 1},
+     {label: 'two', value: 2}
+   ]));
+   this.render(hbs `{{fm-select content=content parentView=parentView}}`);
+   this.$('select').change();
+   assert.equal(this.$('option:selected').val(), this.get('parentView.value'));
+ });
+
+ test('fm-select changes the selected option when the passed in value changes', function(assert) {
+   this.set('modelValue', 2);
+   this.set('content', Ember.A([
+     {label: 'one', value: 1},
+     {label: 'two', value: 2}
+   ]));
+   this.render(hbs `{{fm-select value=modelValue content=content}}`);
+   assert.equal(this.$('option:selected').val(), '2', 'The initial value is set correctly');
+   Ember.run(()=> {
+     this.set('modelValue', 1);
+     assert.equal(this.$('option:selected').val(), '1', 'The selected option updated properly');
+   });
+ });
+
+ test('it allows a prompt to be passed in', function(assert) {
+   this.render(hbs `{{fm-select prompt="Testing"}}`);
+   assert.ok(this.$('option:disabled').length === 1, 'A prompt option was not rendered as expected');
+ });


### PR DESCRIPTION
Fixes some errors with Ember 2 and fm-select. Exposes actions based usage of Ember 2 to allow you to use data down/actions up style.  Keep backwards compatibility with Ember 1.x two binding style usage.  

First three commits are separate because they fix little issues that are somewhat separate but needed to be fixed in order to implement the above.