### PR TITLE
make application-wide configuration (service) overrideable per field

### DIFF
--- a/addon/components/fm-checkbox.js
+++ b/addon/components/fm-checkbox.js
@@ -5,10 +5,8 @@ export default Ember.Component.extend({
   layout: layout,
   classNameBindings: ['checkboxWrapperClass', 'errorClass'],
   fmConfig: Ember.inject.service('fm-config'),
-  checkboxWrapperClass: Ember.computed(function() {
-    return this.get('fmConfig.checkboxWrapperClass');
-  }),
-  errorClass: Ember.computed('errors', function() {
+  checkboxWrapperClass: Ember.computed.reads('fmConfig.checkboxWrapperClass'),
+  errorClass: Ember.computed('errors', 'fmConfig.errorClass', function() {
     if(!Ember.isEmpty(this.get('errors'))) {
       return this.get('fmConfig.errorClass');
     }

--- a/addon/components/fm-field.js
+++ b/addon/components/fm-field.js
@@ -7,10 +7,10 @@ export default Ember.Component.extend({
 
   fmConfig: Ember.inject.service('fm-config'),
 
-  textareaClass: null,
-  inputClass: null,
-  labelClass: null,
-  wrapperClass: null,
+  inputClass: Ember.computed.reads('fmConfig.inputClass'),
+  labelClass: Ember.computed.reads('fmConfig.labelClass'),
+  textareaClass: Ember.computed.reads('fmConfig.textareaClass'),
+  wrapperClass: Ember.computed.reads('fmConfig.wrapperClass'),
 
   init: function() {
     if(!this.get('optionValuePath')) {
@@ -24,17 +24,12 @@ export default Ember.Component.extend({
     });
     this.set('dataAttributes', dataAttributes);
 
-    var classes = this.get('fmConfig').getProperties('wrapperClass', 'labelClass', 'inputClass', 'textareaClass');
-    this.set('wrapperClass', classes.wrapperClass);
-    this.set('labelClass', classes.labelClass);
-    this.set('inputClass', classes.inputClass);
-    this.set('textareaClass', classes.textareaClass);
     this._super(arguments);
   },
   placeholder: null,
   label: null,
   classNameBindings: ['wrapperClass', 'errorClass'],
-  errorClass: Ember.computed('errors', function() {
+  errorClass: Ember.computed('errors', 'fmConfig.errorClass', function() {
     if(!Ember.isEmpty(this.get('errors'))) {
       return this.get('fmConfig.errorClass');
     }

--- a/addon/components/fm-form.js
+++ b/addon/components/fm-form.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
     this._super();
   },
   classNameBindings: ['formClass'],
-  formClass: Ember.computed.alias('fmConfig.formClass'),
+  formClass: Ember.computed.reads('fmConfig.formClass'),
   fmConfig: Ember.inject.service('fm-config'),
   tagName: 'form',
   'for': null,

--- a/addon/components/fm-helptext.js
+++ b/addon/components/fm-helptext.js
@@ -6,7 +6,5 @@ export default Ember.Component.extend({
   tagName: 'span',
   classNameBindings: ['helptextClass'],
   fmConfig: Ember.inject.service('fm-config'),
-  helptextClass: function() {
-    return this.get('fmConfig.helptextClass');
-  }
+  helptextClass: Ember.computed.reads('fmConfig.helptextClass')
 });

--- a/addon/components/fm-radio-group.js
+++ b/addon/components/fm-radio-group.js
@@ -5,15 +5,11 @@ export default Ember.Component.extend({
   layout: layout,
   classNameBindings: ['radioGroupWrapperClass', 'errorClass'],
   fmConfig: Ember.inject.service('fm-config'),
-  errorClass: Ember.computed('errors', function() {
+  errorClass: Ember.computed('errors', 'fmConfig.errorClass', function() {
     if(!Ember.isEmpty(this.get('errors'))) {
       return this.get('fmConfig.errorClass');
     }
   }),
-  radioGroupWrapperClass: Ember.computed(function() {
-    return this.get('fmConfig.radioGroupWrapperClass');
-  }),
-  labelClass: function() {
-    return this.get('fmConfig.labelClass');
-  }
+  radioGroupWrapperClass: Ember.computed.reads('fmConfig.radioGroupWrapperClass'),
+  labelClass: Ember.computed.reads('fmConfig.labelClass')
 });

--- a/addon/components/fm-radio.js
+++ b/addon/components/fm-radio.js
@@ -3,11 +3,9 @@ import layout from '../templates/components/ember-form-master-2000/fm-radio';
 
 export default Ember.Component.extend({
   layout: layout,
-  classNameBindings: 'radioClass',
+  classNameBindings: ['radioClass'],
   fmConfig: Ember.inject.service('fm-config'),
-  radioClass: Ember.computed(function() {
-    return this.get('fmConfig.radioClass');
-  }),
+  radioClass: Ember.computed.reads('fmConfig.radioClass'),
   checked: false,
   updateChecked: Ember.observer('parentView.value', function() {
     this.set('checked', this.get('parentView.value') === this.get('value'));

--- a/addon/components/fm-select.js
+++ b/addon/components/fm-select.js
@@ -10,6 +10,8 @@ export default Ember.Component.extend({
   optionLabelPath: 'label',
   action: Ember.K,
   fmConfig: Ember.inject.service('fm-config'),
+  classNameBindings: ['selectClass'],
+  selectClass: Ember.computed.reads('fmConfig.selectClass'),
 
   // shadow the passed-in `selection` to avoid
   // leaking changes to it via a 2-way binding
@@ -29,8 +31,6 @@ export default Ember.Component.extend({
     if(this.get('value')) {
       this.set('selection', this.get('value'));
     }
-    this.get('classNames').push(this.get('fmConfig.selectClass'));
-
   },
 
   change: function() {

--- a/addon/components/fm-submit.js
+++ b/addon/components/fm-submit.js
@@ -7,8 +7,10 @@ export default Ember.Component.extend({
   fmConfig: Ember.inject.service('fm-config'),
   init: function() {
     this._super(this);
-    this.set('wrapperClass', this.get('fmConfig.wrapperClass'));
-    this.set('submitButtonClasses', this.get('fmConfig.submitButtonClasses').join(' '));
   },
+  submitButtonClasses: Ember.computed('fmConfig.submitButtonClasses', function() {
+    return this.get('fmConfig.submitButtonClasses').join(' ');
+  }),
+  wrapperClass: Ember.computed.reads('fmConfig.wrapperClass'),
   tagName: 'div'
 });

--- a/addon/components/fm-submit.js
+++ b/addon/components/fm-submit.js
@@ -8,9 +8,7 @@ export default Ember.Component.extend({
   init: function() {
     this._super(this);
   },
-  submitButtonClasses: Ember.computed('fmConfig.submitButtonClasses', function() {
-    return this.get('fmConfig.submitButtonClasses').join(' ');
-  }),
+  submitButtonClass: Ember.computed.reads('fmConfig.submitButtonClass'),
   wrapperClass: Ember.computed.reads('fmConfig.wrapperClass'),
   tagName: 'div'
 });

--- a/addon/services/fm-config.js
+++ b/addon/services/fm-config.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Service.extend({
-  submitButtonClasses: ['btn', 'btn-primary'],
+  submitButtonClass: 'btn btn-primary',
   errorClass: 'has-error',
   wrapperClass: 'form-group',
   labelClass: 'control-label',

--- a/addon/templates/components/ember-form-master-2000/fm-submit.hbs
+++ b/addon/templates/components/ember-form-master-2000/fm-submit.hbs
@@ -1,7 +1,7 @@
 <button
   value={{value}}
   disabled={{disabled}}
-  class='{{submitButtonClasses}}'
+  class='{{submitButtonClass}}'
   type="submit">
   {{#if value}}
     {{value}}


### PR DESCRIPTION
make application-wide configuration (service) overrideable per field;
also observes changes in application-wide configuration

Example for http://getbootstrap.com/css/#forms-inline
```
{{#fm-form formClass='form-inline'}}
  {{fm-field labelClass='sr-only' label='Email address'}}
  {{fm-field labelClass='sr-only' label='Passwort'}}
  {{#fm-submit submitButtonClasses=null}}
    Sing in
  {{/fm-submit}}
{{/fm-form}}
```

Also fixes #26 / #35.