### PR TITLE
Fix tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-form-master-2000",
   "dependencies": {
     "ember": "^2.1.0",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
+    "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "^2.1.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",

--- a/tests/integration/components/fm-checkbox-test.js
+++ b/tests/integration/components/fm-checkbox-test.js
@@ -25,7 +25,7 @@ moduleForComponent('fm-checkbox', 'Integration | Component | fm-checkbox', {
 //   assert.equal(this.$('label').text().trim(), 'This is the label', 'the fm-checkbox label matches');
 // });
 
-test('errors are shown after user interaction but not before', function(assert) {
+test('errors are shown after user interaction but not before if fmConfig.showErrorsByDefault is false', function(assert) {
   this.set('errors', ['error message']);
   this.render(hbs `{{fm-checkbox errors=errors}}`);
   assert.ok(

--- a/tests/integration/components/fm-field-test.js
+++ b/tests/integration/components/fm-field-test.js
@@ -1,13 +1,16 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
+import fmConfig from 'ember-form-master-2000/services/fm-config';
 // import {initialize} from 'ember-form-master-2000/initializers/fm-initialize';
 
 moduleForComponent('fm-field', 'Integration | Component | fm-field', {
   integration: true,
   setup: function() {
-    this.container.inject = this.container.injection;
+    // this.container.inject = this.container.injection;
     // initialize(null, this.container);
+    this.register('service:fm-config', fmConfig);
+    this.inject.service('fm-config', { as: 'config'});
   }
 });
 
@@ -97,7 +100,8 @@ test('selection option label is updated when property changes', function(assert)
   assert.equal(this.$('option').text().trim(), 'bar');
 });
 
-test('errors are not shown after user interaction but not before', function(assert) {
+test('errors are shown after user interaction but not before', function(assert) {
+  this.set('config.showErrorsByDefault', false);
   this.set('errors', ['error message']);
   this.render(hbs `{{fm-field errors=errors}}`);
   assert.ok(
@@ -124,7 +128,8 @@ test('errors are not shown after user interaction but not before', function(asse
   );
 });
 
-test('errors are not shown after user interaction but not before (textarea)', function(assert) {
+test('errors are shown after user interaction but not before (textarea)', function(assert) {
+  this.set('config.showErrorsByDefault', false);
   this.set('errors', ['error message']);
   this.render(hbs `{{fm-field type='textarea' errors=errors}}`);
   assert.ok(
@@ -151,7 +156,8 @@ test('errors are not shown after user interaction but not before (textarea)', fu
   );
 });
 
-test('errors are not shown after user interaction but not before (select)', function(assert) {
+test('errors are shown after user interaction but not before (select)', function(assert) {
+  this.set('config.showErrorsByDefault', false);
   this.set('errors', ['error message']);
   this.render(hbs `{{fm-field type='select' errors=errors}}`);
   assert.ok(

--- a/tests/integration/components/fm-form-test.js
+++ b/tests/integration/components/fm-form-test.js
@@ -1,13 +1,16 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import fmConfig from 'ember-form-master-2000/services/fm-config';
 // import {initialize} from 'ember-form-master-2000/initializers/fm-initialize';
 //
 moduleForComponent('fm-form', 'Integration | Component | fm-form', {
   integration: true,
-//   setup: function() {
+   setup: function() {
+     this.register('service:fm-config', fmConfig);
+     this.inject.service('fm-config', { as: 'config' });
 //     this.container.inject = this.container.injection;
 //     initialize(null, this.container);
-//   }
+   }
 });
 //
 // test('renders properly', function(assert) {
@@ -24,6 +27,7 @@ moduleForComponent('fm-form', 'Integration | Component | fm-form', {
 // });
 
 test('form shows errors on submit', function(assert) {
+  this.set('config.showErrorsByDefault', false);
   this.set('errors', ['error message']);
   this.render(hbs `
     {{#fm-form}}


### PR DESCRIPTION
Fixes tests after 53f3430a8ef10101edbcb3e83e8a49455145d508.

Also pins jQuery to 1.11.3 as a work-a-round for this bug in ember.js: https://github.com/emberjs/ember.js/pull/12793