### PR TITLE
[FIX] – Visible errors only visible when errors are present

### DIFF
--- a/addon/components/fm-displays/base.js
+++ b/addon/components/fm-displays/base.js
@@ -6,6 +6,11 @@ export default Ember.Component.extend({
   tagName: '',
   styles: inject.service('fm-config'),
   inputClasses: computed('styles.errorClass', 'styles.inputClass', function(){
-    return ['styles.errorClass', 'styles.inputClass'].map(x => this.get(x));
+    let classNames = ['styles.inputClass'];
+    let visibleErrors = this.get('visibleErrors');
+    if(visibleErrors && visibleErrors.length > 0) {
+      classNames.push('styles.errorClass');
+    }
+    return classNames.map(x => this.get(x));
   })
 });

--- a/addon/components/fm-displays/base.js
+++ b/addon/components/fm-displays/base.js
@@ -5,7 +5,7 @@ const {inject, computed} = Ember;
 export default Ember.Component.extend({
   tagName: '',
   styles: inject.service('fm-config'),
-  inputClasses: computed('styles.errorClass', 'styles.inputClass', function(){
+  inputClasses: computed('styles.errorClass', 'styles.inputClass', 'visibleErrors', function(){
     let classNames = ['styles.inputClass'];
     let visibleErrors = this.get('visibleErrors');
     if(visibleErrors && visibleErrors.length > 0) {

--- a/tests/integration/components/fm-field-test.js
+++ b/tests/integration/components/fm-field-test.js
@@ -128,6 +128,15 @@ test('errors are shown after user interaction but not before', function(assert) 
   );
 });
 
+test('has-error class should only be applied when errors are present', function(assert) {
+  this.set('errors', Ember.A([]));
+  this.render(hbs `{{fm-field widget='textarea' errors=errors}}`);
+  assert.ok(
+    this.$('.has-error').length === 0,
+    'error class is not applied unless errors are present'
+  );
+});
+
 test('errors are shown after user interaction but not before (textarea)', function(assert) {
   this.set('config.showErrorsByDefault', false);
   this.set('errors', Ember.A(['error message']));


### PR DESCRIPTION
## Priority
High – we have a demo on Thursday and I'd like to get this in before that.

## Screenshot
Taken on initial render...
![before-after](https://cloud.githubusercontent.com/assets/186545/15001762/444d69f8-1168-11e6-9a0c-c38410fa23c7.png)


## What Changed & Why
I was building out a widget example for our presentation this Thursday and noticed that my fields always had errors. It was resulting in some weird styling.

## Testing
- [x] Verify the issue in a previous version _(make a field and load the page, it will have the error class)_
- [x] Verify this branch fixes the issue _(make a field and see that `has-error` is not present unless errors are)_

## Bug/Ticket Tracker
NA.

## Documentation
NA.

## In Progress/Follow Up
There was at some time a debate about whether fields should be invalid by default. I for one, do not feel that empty fields should be considered invalid by default _(is that crazy?)_.

## Legal/Security/Privacy
NA.

## Third-Party
NA.

## People
@Emerson
@g-cassie 