### PR TITLE
Use same name attribute for every radio within the same radio-group

### DIFF
--- a/addon/templates/components/fm-widgets/radio-group.hbs
+++ b/addon/templates/components/fm-widgets/radio-group.hbs
@@ -6,5 +6,6 @@
     targetValue=(get option widgetAttrs.optionValuePath)
     label=(get option widgetAttrs.optionLabelPath)
     onUserInteraction=(action 'radioButtonInteraction')
+    name=widgetAttrs.name
   }}
 {{/each}}


### PR DESCRIPTION
## What Changed & Why
The `radio` widget uses a `name` attribute, but the `radio-group` widget doesn't actually pass that param to `radio`, so radio buttons in a radio group don't have any name attribute.

## Testing
List step-by-step how to test the changes.
- [ ] Use a `radio-group` widget
- [ ] Inspect the radio input html
- [ ] It should now have a name attribute 🎉 
