### PR TITLE
Allow disabled attr for checkbox

### DIFF
--- a/addon/templates/components/fm-widgets/checkbox.hbs
+++ b/addon/templates/components/fm-widgets/checkbox.hbs
@@ -2,4 +2,5 @@
   type='checkbox'
   checked=value
   name=widgetAttrs.name
+  disabled=widgetAttrs.disabled
   tabindex=widgetAttrs.tabindex}}


### PR DESCRIPTION
## What Changed & Why
This change allows passing a `disabled` widget attribute to disable a checkbox.

## Testing
List step-by-step how to test the changes.
- [ ] Add `disabled=true` to a checkbox `widgetAttrs`
- [ ] The checkbox is now disabled