### PR TITLE
Removing deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
+.DS_Store
 
 # compiled output
 /dist

--- a/addon/components/fm-field.js
+++ b/addon/components/fm-field.js
@@ -119,23 +119,29 @@ export default Component.extend({
   actions: {
 
     onKeyUp(e, instance) {
-      this.sendAction('onKeyUp', e, instance);
+      if (this.onKeyUp && typeof this.onKeyUp === 'function') {
+        this.onKeyUp(e, instance);
+      }
     },
 
     onBlur(e, instance) {
       this.set('isFocused', false);
-      this.sendAction('onBlur', e, instance);
+      if (this.onBlur && typeof this.onBlur === 'function') {
+        this.onBlur(e, instance);
+      }
     },
 
     onFocus(e, instance) {
       this.set('isFocused', true);
-      this.sendAction('onFocus', e, instance);
+      if (this.onFocus && typeof this.onFocus === 'function') {
+        this.onFocus(e, instance);
+      }
     },
 
     userInteraction() {
       this.set('shouldShowErrors', true);
-      if (this.attrs.onUserInteraction && typeof this.attrs.onUserInteraction === 'function'){
-        this.attrs.onUserInteraction();
+      if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+        this.onUserInteraction();
       }
     },
 

--- a/addon/components/fm-form.js
+++ b/addon/components/fm-form.js
@@ -20,6 +20,8 @@ export default Component.extend({
         childView.set('shouldShowErrors', true);
       }
     });
-    this.sendAction('action', this.get('for'));
+    if (this.action && typeof this.action === 'function') {
+      this.action(e, this.for);
+    }
   }
 });

--- a/addon/components/fm-widgets/checkbox.js
+++ b/addon/components/fm-widgets/checkbox.js
@@ -7,15 +7,26 @@ export default Component.extend({
   layout,
 
   change(e) {
-    this.sendAction('onUserInteraction', e, this);
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction(e, this);
+    }
   },
 
   focusOut(e) {
-    this.sendAction('onUserInteraction', e, this);
-    this.sendAction('onBlur', e, this);
+    if (this.onBlur && typeof this.onBlur === 'function') {
+      this.onBlur(e, this);
+    }
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction(e, this);
+    }
   },
 
   focusIn(e) {
-    this.sendAction('onFocus', e, this);
+    if (this.onFocus && typeof this.onFocus === 'function') {
+      this.onFocus(e, this);
+    }
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction();
+    }
   }
 });

--- a/addon/components/fm-widgets/input.js
+++ b/addon/components/fm-widgets/input.js
@@ -14,16 +14,30 @@ export default TextField.extend({
   }),
 
   focusOut(e) {
-    this.sendAction('onUserInteraction', e, this);
-    this.sendAction('onBlur', e, this);
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction(e, this);
+    }
+    if (this.onBlur && typeof this.onBlur === 'function') {
+      this.onBlur(e, this);
+    }
   },
 
   keyUp(e) {
-    this.sendAction('onKeyUp', e, this);
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction(e, this);
+    }
+    if (this.onKeyUp && typeof this.onKeyUp === 'function') {
+      this.onKeyUp(e, this);
+    }
   },
 
   focusIn(e) {
-    this.sendAction('onFocus', e, this);
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction(e, this);
+    }
+    if (this.onFocus && typeof this.onFocus === 'function') {
+      this.onFocus(e, this);
+    }
   },
 
   afterRender(){

--- a/addon/components/fm-widgets/radio-group.js
+++ b/addon/components/fm-widgets/radio-group.js
@@ -6,8 +6,10 @@ import layout from '../../templates/components/fm-widgets/radio-group';
 export default Component.extend({
   layout,
   actions: {
-    radioButtonInteraction(){
-      this.sendAction('onUserInteraction');
+    radioButtonInteraction() {
+      if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+        this.onUserInteraction();
+      }
     }
   }
 });

--- a/addon/components/fm-widgets/radio.js
+++ b/addon/components/fm-widgets/radio.js
@@ -16,10 +16,17 @@ export default Component.extend({
 
   change() {
     this.set('value', this.get('widgetAttrs.targetValue'));
-    this.sendAction('onUserInteraction');
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction();
+    }
   },
 
-  focusOut() {
-    this.sendAction('onUserInteraction');
+  focusOut(e) {
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction();
+    }
+    if (this.onBlur && typeof this.onBlur === 'function') {
+      this.onBlur(e, this);
+    }
   },
 });

--- a/addon/components/fm-widgets/select.js
+++ b/addon/components/fm-widgets/select.js
@@ -3,8 +3,9 @@
 import layout from '../../templates/components/fm-widgets/select';
 
 import Component from '@ember/component';
-import { set, get } from '@ember/object';
+import { get } from '@ember/object';
 import { inject } from '@ember/service';
+import { isArray } from '@ember/array';
 import { reads, oneWay } from '@ember/object/computed';
 
 export default Component.extend({
@@ -19,16 +20,14 @@ export default Component.extend({
   selectClass: reads('fmConfig.selectClass'),
 
   isDisabled: oneWay('widgetAttrs.disabled'),
+  optionContent: null,
 
-  init() {
-    this._super(arguments);
-    const wAttrs = this.get('widgetAttrs');
-    //if(!!this.attrs.forAttribute) {
-      //this.set('elementId', this.attrs.forAttribute);
-    //}
-
-    if(!wAttrs.content) {
-      set(wAttrs, 'content', []);
+  didReceiveAttrs() {
+    this._super(...arguments);
+    if (!isArray(this.widgetAttrs.content)) {
+      this.set('optionContent', []);
+    } else {
+      this.set('optionContent', this.widgetAttrs.content);
     }
   },
 
@@ -55,15 +54,26 @@ export default Component.extend({
     } else {
       this.attrs.value.update(value);
     }
-    this.sendAction('onUserInteraction');
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction();
+    }
   },
 
   focusOut(e) {
-    this.sendAction('onUserInteraction', e, this);
-    this.sendAction('onBlur', e, this);
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction(e, this);
+    }
+    if (this.onBlur && typeof this.onBlur === 'function') {
+      this.onBlur(e, this);
+    }
   },
 
   focusIn(e) {
-    this.sendAction('onFocus', e, this);
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction(e, this);
+    }
+    if (this.onFocus && typeof this.onFocus === 'function') {
+      this.onFocus(e, this);
+    }
   }
 });

--- a/addon/components/fm-widgets/textarea.js
+++ b/addon/components/fm-widgets/textarea.js
@@ -14,16 +14,30 @@ export default TextArea.extend({
   },
 
   focusOut(e) {
-    this.sendAction('onUserInteraction', e, this);
-    this.sendAction('onBlur', e, this);
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction(e, this);
+    }
+    if (this.onBlur && typeof this.onBlur === 'function') {
+      this.onBlur(e, this);
+    }
   },
 
   keyUp(e) {
-    this.sendAction('onKeyUp', e, this);
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction(e, this);
+    }
+    if (this.onKeyUp && typeof this.onKeyUp === 'function') {
+      this.onKeyUp(e, this);
+    }
   },
 
   focusIn(e) {
-    this.sendAction('onFocus', e, this);
+    if (this.onUserInteraction && typeof this.onUserInteraction === 'function'){
+      this.onUserInteraction(e, this);
+    }
+    if (this.onFocus && typeof this.onFocus === 'function') {
+      this.onFocus(e, this);
+    }
   }
 
 });

--- a/addon/templates/components/fm-widgets/select.hbs
+++ b/addon/templates/components/fm-widgets/select.hbs
@@ -4,7 +4,7 @@
   </option>
 {{/if}}
 
-{{#each this.widgetAttrs.content as |item|}}
+{{#each this.optionContent as |item|}}
   <option value="{{if this.widgetAttrs.optionValuePath (get item this.widgetAttrs.optionValuePath) item}}"
           selected={{is-equal (if this.widgetAttrs.optionValuePath (get item this.widgetAttrs.optionValuePath) item) this.value}}>
     {{get item this.widgetAttrs.optionLabelPath}}

--- a/tests/integration/components/fm-widgets/select-test.js
+++ b/tests/integration/components/fm-widgets/select-test.js
@@ -145,7 +145,7 @@ module('Integration | Component | fm-widget:select', function (hooks) {
   });
 
   test('supports undefined content in widgetAttrs', async function (assert) {
-    await render(hbs`{{fm-widgets/select value=this.value widgetAttrs=(hash content=this.content optionValueLabel='label' optionValuePath='value')}}`);
+    await render(hbs`{{fm-widgets/select value=this.value widgetAttrs=(hash content=content optionValueLabel='label' optionValuePath='value')}}`);
     assert.dom('option').doesNotExist();
     this.set('content', [{ label: 'one', value: 1 }]);
     assert.dom('option').exists({ count: 1 });

--- a/tests/integration/components/fm-widgets/select-test.js
+++ b/tests/integration/components/fm-widgets/select-test.js
@@ -145,7 +145,7 @@ module('Integration | Component | fm-widget:select', function (hooks) {
   });
 
   test('supports undefined content in widgetAttrs', async function (assert) {
-    await render(hbs`{{fm-widgets/select value=this.value widgetAttrs=(hash content=content optionValueLabel='label' optionValuePath='value')}}`);
+    await render(hbs`{{fm-widgets/select value=this.value widgetAttrs=(hash content=this.content optionValueLabel='label' optionValuePath='value')}}`);
     assert.dom('option').doesNotExist();
     this.set('content', [{ label: 'one', value: 1 }]);
     assert.dom('option').exists({ count: 1 });


### PR DESCRIPTION
As we prepare for Ember v4 we need to remove a bunch of deprecations. This PR removes two important ones:

1. Remove the use of `sendAction`. We now expect callbacks to be pass in rather than sending actions up.
2. We needed to remove code that was calling `set` on a hash, which is apparently not allowed anymore.